### PR TITLE
Fix file format query param issue

### DIFF
--- a/wsd-core.el
+++ b/wsd-core.el
@@ -39,7 +39,7 @@
   (let* ((encoded (wsd-encode message))
          (apikey  (wsd-get-apikey-section)))
     (concat "apiVersion=1"
-            "&format=png" wsd-format
+            "&format=" wsd-format
             "&style=" wsd-style
             "&message=" encoded
             apikey)))


### PR DESCRIPTION
Based on the surrounding code this _looks_ like a bug, in that I think it will generate a url query fragment `&format=pngpng` rather than `&format=png`.
