### PR TITLE
Fix bug creating many preview buffers for non-persisted source

### DIFF
--- a/wsd-core.el
+++ b/wsd-core.el
@@ -104,7 +104,7 @@
 
 (defun wsd-get-image-buffer-name (buffer-name file-name)
   "Returns an appropriate corresponding buffer name to display resulting image in."
-  (if (not (buffer-name))
+  (if (not buffer-name)
       (concat "wsd-temp-buffer." wsd-format)
     file-name))
 


### PR DESCRIPTION
This was rather subtle :-)

With this fix I buffers are properly re-used when using C-c C-c repeatedly in a non-persisted wsd buffer.
