### PR TITLE
Fix compilation warning

### DIFF
--- a/wsd-core.el
+++ b/wsd-core.el
@@ -78,7 +78,7 @@
   "Parses a single error-response as returned by the WSD server."
   (with-temp-buffer
     (insert entry)
-    (beginning-of-buffer)
+    (goto-char (point-min))
     (search-forward-regexp "Line \\([[:digit:]]+\\): \\(.*\\)")
     (let* ((line-num          (string-to-number (match-string 1)))
 	   (error-description (match-string 2)))


### PR DESCRIPTION
In wsd-parse-error:
wsd-core.el:80:13:Warning: `beginning-of-buffer' is for interactive use only;
    use`(goto-char (point-min))' instead.
