### PR TITLE
Remove unnecessary flag to turn on extended regexes

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ package: $(PACKAGE_DIR)
 $(PACKAGE_DIR):
 	mkdir -p $@
 	cp -r ../$(PACKAGE_SHORTNAME)/* $@
-	sed -re "s/VERSION/$(VERSION)/" $@/$(PACKAGE_SHORTNAME)-pkg.el.template > $@/$(PACKAGE_SHORTNAME)-pkg.el
+	sed -e "s/VERSION/$(VERSION)/" $@/$(PACKAGE_SHORTNAME)-pkg.el.template > $@/$(PACKAGE_SHORTNAME)-pkg.el
 
 test:
 	+ $(EMACS) -l wsd-tests.el -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
... it is a gnu-only extension, and is rejected by e.g. sed on OS X
Yosemite. Presumably on BSDs too.
