### PR TITLE
Encode message so that it can be safely transported in the url

### DIFF
--- a/wsd-core.el
+++ b/wsd-core.el
@@ -51,13 +51,7 @@ Delimiters included.  If no api-key is used, returns nil."
 
 (defun wsd-encode (message)
   "Encodes the provided `MESSAGE' into something which can be transported over HTTP."
-  (let* ((encode1 (replace-regexp-in-string (regexp-quote "+")
-                                            (regexp-quote "%2B")
-                                            message))
-         ;; otherwise comments in script will break export!
-         (encode2 (replace-regexp-in-string "#" "%23" encode1))
-         (encode3 (url-encode-url encode2)))
-    encode3))
+  (url-hexify-string message))
 
 (defun wsd-get-request-data (message)
   "Transform `MESSAGE' into request-data for a HTTP post to the wsd.com API."

--- a/wsd-tests.el
+++ b/wsd-tests.el
@@ -197,6 +197,13 @@
                     (regexp-quote (string char))
                     url-query))))))
 
+(ert-deftest message-is-correctly-urlencoded ()
+  (let* ((test-chars "% &;/?:@=<>#{}|\^[]`")
+		 (encoded (wsd-encode test-chars)))
+	(should (string=
+			 encoded
+			 "%25%20%26%3B%2F%3F%3A%40%3D%3C%3E%23%7B%7D%7C%1B%5D%60"))))
+
 ;; (ert-deftest flycheck-errors-are-returned ()
 ;;   (let* ((result (wsd-flycheck-parse-errors
 ;;                   'wsd-mode-checker


### PR DESCRIPTION
The url-encode-url function does not escape all characters that cause problems
when the message is sent as a url encoded form parameter. I discovered this
when some of my diagrams failed because I had comments with an & in them. I
believe url-encode-url is intended for things that are already URIs, whereas
when a parameter value needs to be encoded as here url-hexify-string is the
correct function to use
(https://www.gnu.org/software/emacs/manual/html_node/url/URI-Encoding.html).

I suppose wsd-encode can be inlined now since it just wraps url-hexify-string,
but I'll leave that decision to the maintainer.