### PR TITLE
Convert README badge to SVG

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 wsd-mode is a Emacs major-mode for
 [[http://www.websequencediagrams.com][www.websequencediagrams.com]].
 
-[[https://travis-ci.org/josteink/wsd-mode/][Travis-CI build-page]]. Build-status: [[https://api.travis-ci.org/josteink/wsd-mode.png]]
+[[https://travis-ci.org/josteink/wsd-mode/][Travis-CI build-page]]. Build-status: [[https://api.travis-ci.org/josteink/wsd-mode.svg]]
 
 ** wsd-mode explained in two screenshots
 


### PR DESCRIPTION
Because raster badges make eyes bleed on retina displays. :sunglasses:

